### PR TITLE
Add `Wedge`-like case map method

### DIFF
--- a/src/__tests__/remote-failure.ts
+++ b/src/__tests__/remote-failure.ts
@@ -43,6 +43,30 @@ test("caseOf", (t) => {
       caseMap.success
     )
   );
+
+  t.is(failureRD.caseOf(caseMap), 3);
+});
+
+test('wedgeCaseOf', t => {
+  const { failureRD } = t.context;
+  const wedgeCaseMap = {
+    none: 1,
+    failure: () => 2,
+    some: () => 3
+  };
+
+  t.is(
+    failureRD.wedgeCaseOf(wedgeCaseMap),
+    failureRD.fold(
+      wedgeCaseMap.none,
+      wedgeCaseMap.none,
+      wedgeCaseMap.failure,
+      wedgeCaseMap.some,
+      wedgeCaseMap.some
+    )
+  );
+
+  t.is(failureRD.wedgeCaseOf(wedgeCaseMap), 2);
 });
 
 test("getOrElse", (t) => {

--- a/src/__tests__/remote-initial.ts
+++ b/src/__tests__/remote-initial.ts
@@ -24,7 +24,7 @@ test.beforeEach((t) => {
 });
 
 test("caseOf", (t) => {
-  const { failureRD } = t.context;
+  const { initialRD } = t.context;
   const caseMap = {
     initial: 1,
     pending: 2,
@@ -34,8 +34,8 @@ test("caseOf", (t) => {
   };
 
   t.is(
-    failureRD.caseOf(caseMap),
-    failureRD.fold(
+    initialRD.caseOf(caseMap),
+    initialRD.fold(
       caseMap.initial,
       caseMap.pending,
       caseMap.failure,
@@ -43,6 +43,29 @@ test("caseOf", (t) => {
       caseMap.success
     )
   );
+  t.is(initialRD.caseOf(caseMap), 1);
+});
+
+test("wedgeCaseOf", (t) => {
+  const { initialRD } = t.context;
+  const wedgeCaseMap = {
+    none: 1,
+    failure: () => 2,
+    some: () => 3,
+  };
+
+  t.is(
+    initialRD.wedgeCaseOf(wedgeCaseMap),
+    initialRD.fold(
+      wedgeCaseMap.none,
+      wedgeCaseMap.none,
+      wedgeCaseMap.failure,
+      wedgeCaseMap.some,
+      wedgeCaseMap.some
+    )
+  );
+
+  t.is(initialRD.wedgeCaseOf(wedgeCaseMap), 1);
 });
 
 test("getOrElse", (t) => {

--- a/src/__tests__/remote-pending.ts
+++ b/src/__tests__/remote-pending.ts
@@ -24,7 +24,7 @@ test.beforeEach((t) => {
 });
 
 test("caseOf", (t) => {
-  const { failureRD } = t.context;
+  const { pendingRD } = t.context;
   const caseMap = {
     initial: 1,
     pending: 2,
@@ -34,8 +34,8 @@ test("caseOf", (t) => {
   };
 
   t.is(
-    failureRD.caseOf(caseMap),
-    failureRD.fold(
+    pendingRD.caseOf(caseMap),
+    pendingRD.fold(
       caseMap.initial,
       caseMap.pending,
       caseMap.failure,
@@ -43,6 +43,29 @@ test("caseOf", (t) => {
       caseMap.success
     )
   );
+  t.is(pendingRD.caseOf(caseMap), 2);
+});
+
+test("wedgeCaseOf", (t) => {
+  const { pendingRD } = t.context;
+  const wedgeCaseMap = {
+    none: 1,
+    failure: () => 2,
+    some: () => 3,
+  };
+
+  t.is(
+    pendingRD.wedgeCaseOf(wedgeCaseMap),
+    pendingRD.fold(
+      wedgeCaseMap.none,
+      wedgeCaseMap.none,
+      wedgeCaseMap.failure,
+      wedgeCaseMap.some,
+      wedgeCaseMap.some
+    )
+  );
+
+  t.is(pendingRD.wedgeCaseOf(wedgeCaseMap), 1);
 });
 
 test("getOrElse", (t) => {

--- a/src/__tests__/remote-refresh.ts
+++ b/src/__tests__/remote-refresh.ts
@@ -43,6 +43,29 @@ test("caseOf", (t) => {
       caseMap.success
     )
   );
+  t.is(refreshRD.caseOf(caseMap), 4);
+});
+
+test('wedgeCaseOf', t => {
+  const { refreshRD } = t.context;
+  const wedgeCaseMap = {
+    none: 1,
+    failure: () => 2,
+    some: () => 3
+  };
+
+  t.is(
+    refreshRD.wedgeCaseOf(wedgeCaseMap),
+    refreshRD.fold(
+      wedgeCaseMap.none,
+      wedgeCaseMap.none,
+      wedgeCaseMap.failure,
+      wedgeCaseMap.some,
+      wedgeCaseMap.some
+    )
+  );
+
+  t.is(refreshRD.wedgeCaseOf(wedgeCaseMap), 3);
 });
 
 test("getOrElse", (t) => {

--- a/src/__tests__/remote-success.ts
+++ b/src/__tests__/remote-success.ts
@@ -43,6 +43,29 @@ test("caseOf", (t) => {
       caseMap.success
     )
   );
+  t.is(successRD.caseOf(caseMap), 5);
+});
+
+test('wedgeCaseOf', t => {
+  const { successRD } = t.context;
+  const wedgeCaseMap = {
+    none: 1,
+    failure: () => 2,
+    some: () => 3
+  };
+
+  t.is(
+    successRD.wedgeCaseOf(wedgeCaseMap),
+    successRD.fold(
+      wedgeCaseMap.none,
+      wedgeCaseMap.none,
+      wedgeCaseMap.failure,
+      wedgeCaseMap.some,
+      wedgeCaseMap.some
+    )
+  );
+
+  t.is(successRD.wedgeCaseOf(wedgeCaseMap), 3);
 });
 
 test("getOrElse", (t) => {

--- a/src/failure.ts
+++ b/src/failure.ts
@@ -20,6 +20,7 @@ import {
   IRemoteData,
   RemoteData,
   RemoteJSON,
+  WedgeCaseMap,
 } from "./remote-data";
 
 export class RemoteFailure<L, A> implements IRemoteData<L, A> {
@@ -70,6 +71,10 @@ export class RemoteFailure<L, A> implements IRemoteData<L, A> {
   }
 
   caseOf<B>(caseMap: CaseMap<L, A, B>): B {
+    return caseMap.failure(this.error);
+  }
+
+  wedgeCaseOf<B>(caseMap: WedgeCaseMap<L, A, B>): B {
     return caseMap.failure(this.error);
   }
 

--- a/src/initial.ts
+++ b/src/initial.ts
@@ -12,6 +12,7 @@ import {
   IRemoteData,
   RemoteData,
   RemoteJSON,
+  WedgeCaseMap,
 } from "./remote-data";
 
 export class RemoteInitial<L, A> implements IRemoteData<L, A> {
@@ -55,6 +56,10 @@ export class RemoteInitial<L, A> implements IRemoteData<L, A> {
 
   caseOf<B>(caseMap: CaseMap<L, A, B>): B {
     return caseMap.initial;
+  }
+
+  wedgeCaseOf<B>(caseMap: WedgeCaseMap<L, A, B>): B {
+    return caseMap.none;
   }
 
   foldL<B>(

--- a/src/pending.ts
+++ b/src/pending.ts
@@ -13,6 +13,7 @@ import {
   IRemoteData,
   RemoteData,
   RemoteJSON,
+  WedgeCaseMap,
 } from "./remote-data";
 
 export class RemotePending<L, A> implements IRemoteData<L, A> {
@@ -62,6 +63,10 @@ export class RemotePending<L, A> implements IRemoteData<L, A> {
 
   caseOf<B>(caseMap: CaseMap<L, A, B>): B {
     return caseMap.pending;
+  }
+
+  wedgeCaseOf<B>(caseMap: WedgeCaseMap<L, A, B>): B {
+    return caseMap.none;
   }
 
   foldL<B>(

--- a/src/refresh.ts
+++ b/src/refresh.ts
@@ -20,6 +20,7 @@ import {
   IRemoteData,
   RemoteData,
   RemoteJSON,
+  WedgeCaseMap,
 } from "./remote-data";
 
 export class RemoteRefresh<L, A> implements IRemoteData<L, A> {
@@ -83,6 +84,10 @@ export class RemoteRefresh<L, A> implements IRemoteData<L, A> {
 
   caseOf<B>(caseMap: CaseMap<L, A, B>): B {
     return caseMap.refresh(this.value);
+  }
+
+  wedgeCaseOf<B>(caseMap: WedgeCaseMap<L, A, B>): B {
+    return caseMap.some(this.value);
   }
 
   foldL<B>(

--- a/src/remote-data.ts
+++ b/src/remote-data.ts
@@ -113,8 +113,8 @@ export interface IRemoteData<L, A> {
   ap: <B>(fab: RemoteData<L, Function1<A, B>>) => RemoteData<L, B>;
 
   /**
-   * Needed for "unwrap" value from `RemoteData` "container". It takes a
-   * mapping from `RemoteData` types to another value.
+   * Unwraps a value from `RemoteData. It takes a mapping from `RemoteData`
+   * types to another value.
    *
    * @example
    *
@@ -137,6 +137,31 @@ export interface IRemoteData<L, A> {
    * success(21).caseOf(caseMap) will return 22
    */
   caseOf: <B>(caseMap: CaseMap<L, A, B>) => B;
+
+  /**
+   * A variation of `caseMap` that collapses some of the cases. This is similar
+   * to the Haskell type "wedge" (hence the name), that is isomorphic to
+   * `Option<Either<L, A>>`, but allows you to match the variants all at once.
+   *
+   * @example
+   *
+   * const caseMap: WedgeCaseMap = {
+   *     none: "none",
+   *     failure: (err) => "failed",
+   *     some: (data) => data,
+   * }
+   *
+   * initial.wedgeCaseOf(caseMap) will return "none"
+   *
+   * pending.wedgeCaseOf(caseMap) will return "none"
+   *
+   * failure(new Error('error text')).wedgeCaseOf(caseMap) will return "failed"
+   *
+   * refresh(21).wedgeCaseOf(caseMap) will return 21
+   *
+   * success(21).wedgeCaseOf(caseMap) will return 21
+   */
+  wedgeCaseOf: <B>(wedgeCaseMap: WedgeCaseMap<L, A, B>) => B;
 
   /**
    * Takes a function `f` and returns the result of applying it to
@@ -345,6 +370,12 @@ export interface CaseMap<L, A, B> {
   pending: B;
   refresh: Function1<A, B>;
   success: Function1<A, B>;
+}
+
+export interface WedgeCaseMap<L, A, B> {
+  none: B;
+  failure: Function1<L, B>;
+  some: Function1<A, B>;
 }
 
 /**

--- a/src/success.ts
+++ b/src/success.ts
@@ -21,6 +21,7 @@ import {
   IRemoteData,
   RemoteData,
   RemoteJSON,
+  WedgeCaseMap,
 } from "./remote-data";
 
 export class RemoteSuccess<L, A> implements IRemoteData<L, A> {
@@ -84,6 +85,10 @@ export class RemoteSuccess<L, A> implements IRemoteData<L, A> {
 
   caseOf<B>(caseMap: CaseMap<L, A, B>): B {
     return caseMap.success(this.value);
+  }
+
+  wedgeCaseOf<B>(caseMap: WedgeCaseMap<L, A, B>): B {
+    return caseMap.some(this.value);
   }
 
   foldL<B>(


### PR DESCRIPTION
Adding everyone here for some knowledge sharing. I'll also make a short slide about this for next Eng Sync based on actual use in our code.

The basic gist of this is, while we care deeply in many cases about all five states, but many times the client treats the `RemoteInitial` and `RemotePending` cases with the same UI, `RemoteRefresh` and `RemoteSuccess` the same, and `RemoteFailure` as a separate case.

## How do we intend on using this?

```tsx
type RemoteFoo = RemoteData<string[], Foo[]>;
return remoteFoos.wedgeCaseOf({
  none: <Loader />,
  failure: (errors: string[]) => errors.map((error) => <Error key={error}>{error}</Error>,
  some: (foos: Foo[]) => foos.map((foo) => <Foo foo={foo} />,
});
```

We commonly do this instead (which ignores the error case):

```tsx
return remoteFoos.toOption().fold(
  <Loader />,
  (foos: Foo[]) => foos.map((foo) => <Foo foo={foo} />
);
```

Or (which can be awkward if the success case is complex):

```tsx
return remoteFoos.caseOf({
  initial: <Loader />,
  pending: <Loader />,
  failure: (errors: string[]) => errors.map((error) => <Error key={error}>{error}</Error>,
  refresh: (foos: Foo[]) => foos.map((foo) => <Foo foo={foo} />,
  success: (foos: Foo[]) => foos.map((foo) => <Foo foo={foo} />,
});
```

## What's with the name `Wedge`?

I try to avoid novel concepts—probably why I like functional programming: lots of prior art that has been thought deeply about. Where possible, I like to use existing ecosystems (hence the `fp-ts`) or existing concepts. When exploring the existing solution space related to this `Option<Either<L, A>>` type, I was directed to this: https://hackage.haskell.org/package/smash-0.1.1.0/docs/Data-Wedge.html

> In practice, this type is isomorphic to `Maybe (Either a b)` - the type with two possibly non-exclusive values and an empty case.

Bingo.

### What about making an actual `Wedge` type?

I kinda want to do that, honestly, but this is a pretty trivial change, so seemed like a good first stop.